### PR TITLE
CCM-5100: Revert changes to the way page titles are displayed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # NHS Notify Code Owners
 
-* @rossbugginsnhs @m-houston @edmundcraske2-nhs @timireland
+* @NHSDigital/nhs-notify-code-owners
 
 # Default protection for codeowners, must be last in file.
 /.github/CODEOWNERS @NHSDigital/nhs-notify-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # NHS Notify Code Owners
 
-* @NHSDigital/nhs-notify-code-owners
+* @NHSDigital/nhs-notify-amet
 
 # Default protection for codeowners, must be last in file.
 /.github/CODEOWNERS @NHSDigital/nhs-notify-code-owners

--- a/docs/_includes/page-info-header.html
+++ b/docs/_includes/page-info-header.html
@@ -2,10 +2,10 @@
   assign wordWarning = 200 %} {% assign wordCount = content | number_of_words%} {%
   assign readTime = wordCount | divided_by: 100.0 | ceil %} {% if page.sub_title
   %}
-  <h1>{{ page.name }}</h1>
+  <h1>{{ page.title }}</h1>
   <p class="text-medium text-grey-dk-300 mb-0">{{ page.summary }}</p>
   {% else %}
-  <h1>{{ page.name }}</h1>
+  <h1>{{ page.title }}</h1>
   {% endif %}
 
   <div class="page-info">

--- a/docs/collections/_repos/nhs-notify-iam-webauth.md
+++ b/docs/collections/_repos/nhs-notify-iam-webauth.md
@@ -1,7 +1,6 @@
 ---
 repo-name: nhs-notify-iam-webauth
 owners: [ "rossbugginsnhs", "m-houston" ]
-title: nhs-notify-iam-webauth
 name: Notify IAM Web Authentication
 description: OIDC Authentication Micro-Frontend for Web UI
 author: "Mike Houston"

--- a/docs/collections/_repos/nhs-notify-iam-webauth.md
+++ b/docs/collections/_repos/nhs-notify-iam-webauth.md
@@ -8,7 +8,7 @@ order: 3
 parent: Repositories
 ---
 
-### Purpose
+# Purpose
 
 This repository contains a Micro-Frontend (MFE) web application which handles user login using a Cognito User Pool
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Revert the way that titles are rendered
- Update the CODEOWNERS to use team rather than hard-coded users.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

- Earlier changes broke the way titles were displayed on pages without a `name` frontmatter property set
- Team members changing requires an update to each repo where they are listed as a codeowner

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
